### PR TITLE
Fix miniupnpc version detection

### DIFF
--- a/airdcpp-core/airdcpp/Mapper_MiniUPnPc.cpp
+++ b/airdcpp-core/airdcpp/Mapper_MiniUPnPc.cpp
@@ -97,10 +97,10 @@ bool Mapper_MiniUPnPc::init() {
 	if(!url.empty())
 		return true;
 
-#ifdef HAVE_OLD_MINIUPNPC
-	UPNPDev* devices = upnpDiscover(2000, localIp.empty() ? nullptr : localIp.c_str(), 0, 0);
-#else
+#if MINIUPNPC_API_VERSION < 14
 	UPNPDev* devices = upnpDiscover(2000, localIp.empty() ? nullptr : localIp.c_str(), 0, 0, v6, 0);
+#else
+  UPNPDev* devices = upnpDiscover(2000, localIp.empty() ? nullptr : localIp.c_str(), 0, 0, v6, 2, 0);
 #endif
 	if(!devices)
 		return false;


### PR DESCRIPTION
Drop support for old lib and properly detect new versions. Fixes https://github.com/maksis/airdcpp-webclient/issues/25