### PR TITLE
Fix: tautological condition, and typo

### DIFF
--- a/airdcpp-core/airdcpp/connection/http/HttpConnection.cpp
+++ b/airdcpp-core/airdcpp/connection/http/HttpConnection.cpp
@@ -222,7 +222,7 @@ void HttpConnection::on(BufferedSocketListener::Line, const string& aLine) noexc
 				string proto, queryTmp, fragment;
 				LinkUtil::decodeUrl(currentUrl, proto, server, port, file, queryTmp, fragment);
 				string tmp = proto + "://" + server;
-				if(port != "80" || port != "443")
+				if(port != "80" && port != "443")
 					tmp += ':' + port;
 				location = tmp + location;
 			} else {

--- a/airdcpp-core/airdcpp/connection/socket/BufferedSocket.cpp
+++ b/airdcpp-core/airdcpp/connection/socket/BufferedSocket.cpp
@@ -376,7 +376,7 @@ void BufferedSocket::threadSendFile(InputStream* file) {
 				writeSize = min(sockSize / 2, writeBufTmp.size() - writePos);
 				written = useLimiter ? 
 					ThrottleManager::getInstance()->write(sock.get(), &writeBufTmp[writePos], writeSize) : 
-					sock->write(&writeBufTmp[writePos], writeSize);
+					sock->read(&inbuf[0], inbuf.size());
 			}
 			
 			if(written > 0) {

--- a/airdcpp-core/airdcpp/connection/socket/BufferedSocket.cpp
+++ b/airdcpp-core/airdcpp/connection/socket/BufferedSocket.cpp
@@ -376,7 +376,7 @@ void BufferedSocket::threadSendFile(InputStream* file) {
 				writeSize = min(sockSize / 2, writeBufTmp.size() - writePos);
 				written = useLimiter ? 
 					ThrottleManager::getInstance()->write(sock.get(), &writeBufTmp[writePos], writeSize) : 
-					sock->read(&inbuf[0], inbuf.size());
+					sock->write(&writeBufTmp[writePos], writeSize);
 			}
 			
 			if(written > 0) {

--- a/airdcpp-core/airdcpp/modules/AutoSearch.cpp
+++ b/airdcpp-core/airdcpp/modules/AutoSearch.cpp
@@ -431,7 +431,7 @@ void AutoSearch::saveToXml(SimpleXML& xml) {
 	xml.addChildAttrib("Remove", getRemove());
 	xml.addChildAttrib("Target", getTarget());
 	xml.addChildAttrib("MatcherType", getMethod());
-	xml.addChildAttrib("MatcherString", getMatcherString()),
+	xml.addChildAttrib("MatcherString", getMatcherString());
 	xml.addChildAttrib("UserMatch", getNickPattern());
 	xml.addChildAttrib("ExpireTime", getExpireTime());
 	xml.addChildAttrib("CheckAlreadyQueued", getCheckAlreadyQueued());

--- a/airdcpp-core/airdcpp/modules/AutoSearch.cpp
+++ b/airdcpp-core/airdcpp/modules/AutoSearch.cpp
@@ -430,7 +430,7 @@ void AutoSearch::saveToXml(SimpleXML& xml) {
 	xml.addChildAttrib("Action", getAction());
 	xml.addChildAttrib("Remove", getRemove());
 	xml.addChildAttrib("Target", getTarget());
-	xml.addChildAttrib("MatcherType", getMethod()),
+	xml.addChildAttrib("MatcherType", getMethod());
 	xml.addChildAttrib("MatcherString", getMatcherString()),
 	xml.addChildAttrib("UserMatch", getNickPattern());
 	xml.addChildAttrib("ExpireTime", getExpireTime());


### PR DESCRIPTION
## What this fixes

### 1. Tautological condition `port != "80" || port != "443"` in `HttpConnection`
**File**: `airdcpp-core/airdcpp/connection/http/HttpConnection.cpp:227`

`port != "80" || port != "443"` is always true (if port is "80", the second part is true; if "443", the first part is true). This causes the port number to always be appended to redirect URLs, even for standard HTTP/HTTPS ports 80 and 443.

→ Changed `||` to `&&`.

### 2. Comma used instead of semicolons in `AutoSearch::saveToXml`
**File**: `airdcpp-core/airdcpp/modules/AutoSearch.cpp:433-434`

Two lines end with `,` instead of `;`. While technically valid due to the comma operator, this is clearly a typo and inconsistent with every other line in the same block.

→ Replaced `,` with `;`.

*Find using AI, on https://github.com/airdcpp-web/airdcpp-webclient/commit/ff18afdc63b4f0a374d517a0e17084c2a128faf7*