### PR TITLE
Fix SSL fallthrough, BytesSent reporting

### DIFF
--- a/airdcpp-core/airdcpp/connection/socket/BufferedSocket.cpp
+++ b/airdcpp-core/airdcpp/connection/socket/BufferedSocket.cpp
@@ -337,8 +337,8 @@ void BufferedSocket::threadSendFile(InputStream* file) {
 			size_t bytesRead = readBuf.size() - readPos;
 			size_t actual = file->read(&readBuf[readPos], bytesRead);
 
-			if(bytesRead > 0) {
-				fire(BufferedSocketListener::BytesSent(), bytesRead, 0);
+			if(actual > 0) {
+				fire(BufferedSocketListener::BytesSent(), actual, 0);
 			}
 
 			if(actual == 0) {
@@ -390,8 +390,8 @@ void BufferedSocket::threadSendFile(InputStream* file) {
 					size_t bytesRead = min(readBuf.size() - readPos, readBuf.size() / 2);
 					size_t actual = file->read(&readBuf[readPos], bytesRead);
 
-					if(bytesRead > 0) {
-						fire(BufferedSocketListener::BytesSent(), bytesRead, 0);
+					if(actual > 0) {
+						fire(BufferedSocketListener::BytesSent(), actual, 0);
 					}
 
 					if(actual == 0) {

--- a/airdcpp-core/airdcpp/connection/socket/SSLSocket.cpp
+++ b/airdcpp-core/airdcpp/connection/socket/SSLSocket.cpp
@@ -131,9 +131,6 @@ bool SSLSocket::waitWant(int ret, uint64_t millis) {
 		dcdebug("SSL: Unexpected fallthrough, error code %d\n", err);
 		return false;
 	}
-	dcdebug("SSL: Unexpected fallthrough");
-	// There was no error?
-	return true;
 }
 
 int SSLSocket::read(void* aBuffer, size_t aBufLen) {

--- a/airdcpp-core/airdcpp/connection/socket/SSLSocket.cpp
+++ b/airdcpp-core/airdcpp/connection/socket/SSLSocket.cpp
@@ -126,7 +126,10 @@ bool SSLSocket::waitWant(int ret, uint64_t millis) {
 	case SSL_ERROR_WANT_WRITE:
 		return wait(millis, true, false).second;
 	// Check if this is a fatal error...
-	default: checkSSL(ret);
+	default: 
+		checkSSL(ret);
+		dcdebug("SSL: Unexpected fallthrough, error code %d\n", err);
+		return false;
 	}
 	dcdebug("SSL: Unexpected fallthrough");
 	// There was no error?


### PR DESCRIPTION
## What this fixes

### 1. Silent fallthrough in `SSLSocket::waitWant`
**File**: `airdcpp-core/airdcpp/connection/socket/SSLSocket.cpp:121-133`

In the `default:` case of the error switch, `checkSSL(ret)` is called. If it doesn't throw, execution falls through to `return true` — incorrectly reporting success. The debug comment `"SSL: Unexpected fallthrough"` confirms the devs knew this path was possible.

→ Added `return false;` after `checkSSL()` in the default case.

### 2. `BytesSent` fires with requested bytes instead of actual bytes read
**File**: `airdcpp-core/airdcpp/connection/socket/BufferedSocket.cpp:340,394`

The `BytesSent` notification uses `bytesRead` (the amount requested from `file->read()`) instead of `actual` (the amount actually read). If the file read returns less than requested, progress reporting is inflated.

→ Changed to use `actual` instead of `bytesRead`.

*Find using AI, on https://github.com/airdcpp-web/airdcpp-webclient/commit/ff18afdc63b4f0a374d517a0e17084c2a128faf7*