### PR TITLE
Replace boost::noncopyable with deleted copy/assign

### DIFF
--- a/airdcpp-core/airdcpp/connection/ConnectionManager.h
+++ b/airdcpp-core/airdcpp/connection/ConnectionManager.h
@@ -49,8 +49,10 @@ private:
 	static FastCriticalSection cs;
 };
 
-class ConnectionQueueItem : public boost::noncopyable, public Flags {
+class ConnectionQueueItem : public Flags {
 public:
+	ConnectionQueueItem(const ConnectionQueueItem&) = delete;
+	ConnectionQueueItem& operator=(const ConnectionQueueItem&) = delete;
 	using Ptr = ConnectionQueueItem *;
 	using List = vector<Ptr>;
 	

--- a/airdcpp-core/airdcpp/connection/UserConnection.h
+++ b/airdcpp-core/airdcpp/connection/UserConnection.h
@@ -35,10 +35,11 @@
 namespace dcpp {
 
 class UserConnection : public Speaker<UserConnectionListener>, 
-	private BufferedSocketListener, public Flags, private CommandHandler<UserConnection>,
-	private boost::noncopyable
+	private BufferedSocketListener, public Flags, private CommandHandler<UserConnection>
 {
 public:
+	UserConnection(const UserConnection&) = delete;
+	UserConnection& operator=(const UserConnection&) = delete;
 	friend class ConnectionManager;
 	
 	static const string FEATURE_MINISLOTS;

--- a/airdcpp-core/airdcpp/connection/http/HttpConnection.h
+++ b/airdcpp-core/airdcpp/connection/http/HttpConnection.h
@@ -38,9 +38,11 @@ public:
 };
 
 
-class HttpConnection : private BufferedSocketListener, public Speaker<HttpConnectionListener>, public boost::noncopyable
+class HttpConnection : private BufferedSocketListener, public Speaker<HttpConnectionListener>
 {
 public:
+	HttpConnection(const HttpConnection&) = delete;
+	HttpConnection& operator=(const HttpConnection&) = delete;
 	HttpConnection(bool aIsUnique = false, const HttpOptions& aOptions = HttpOptions());
 	virtual ~HttpConnection();
 

--- a/airdcpp-core/airdcpp/connection/http/HttpDownload.h
+++ b/airdcpp-core/airdcpp/connection/http/HttpDownload.h
@@ -26,7 +26,9 @@ namespace dcpp {
 using std::string;
 
 /** Helper struct to manage a single HTTP download. Calls a completion function when finished. */
-struct HttpDownload : private HttpConnectionListener, private boost::noncopyable {
+struct HttpDownload : private HttpConnectionListener {
+	HttpDownload(const HttpDownload&) = delete;
+	HttpDownload& operator=(const HttpDownload&) = delete;
 	HttpConnection* c;
 	string buf;
 	string status;

--- a/airdcpp-core/airdcpp/connection/socket/Socket.h
+++ b/airdcpp-core/airdcpp/connection/socket/Socket.h
@@ -46,7 +46,7 @@ const int INVALID_SOCKET = -1;
 #include <airdcpp/util/Util.h>
 #include <airdcpp/core/classes/Exception.h>
 
-#include <boost/noncopyable.hpp>
+
 #include <memory>
 
 namespace dcpp {
@@ -65,9 +65,11 @@ private:
 };
 
 /** RAII socket handle */
-class SocketHandle : public boost::noncopyable {
+class SocketHandle {
 public:
 	SocketHandle() : sock(INVALID_SOCKET) { }
+	SocketHandle(const SocketHandle&) = delete;
+	SocketHandle& operator=(const SocketHandle&) = delete;
 	explicit SocketHandle(socket_t sock) : sock(sock) { }
 	~SocketHandle() { reset(); }
 
@@ -81,9 +83,11 @@ private:
 	socket_t sock;
 };
 
-class Socket : public boost::noncopyable
+class Socket
 {
 public:
+	Socket(const Socket&) = delete;
+	Socket& operator=(const Socket&) = delete;
 	enum SocketType {
 		TYPE_TCP = IPPROTO_TCP,
 		TYPE_UDP = IPPROTO_UDP

--- a/airdcpp-core/airdcpp/connectivity/Mapper.h
+++ b/airdcpp-core/airdcpp/connectivity/Mapper.h
@@ -23,16 +23,18 @@
 #include <set>
 #include <utility>
 
-#include <boost/noncopyable.hpp>
+
 
 namespace dcpp {
 
 using std::string;
 
 /** abstract class to represent an implementation usable by MappingManager. */
-class Mapper : boost::noncopyable
+class Mapper
 {
 public:
+	Mapper(const Mapper&) = delete;
+	Mapper& operator=(const Mapper&) = delete;
 	Mapper(const string& localIp, bool v6);
 	virtual ~Mapper() = default;
 

--- a/airdcpp-core/airdcpp/core/Singleton.h
+++ b/airdcpp-core/airdcpp/core/Singleton.h
@@ -21,14 +21,16 @@
 
 #include <airdcpp/core/header/debug.h>
 
-#include <boost/noncopyable.hpp>
+
 
 namespace dcpp {
 
 template<typename T>
-class Singleton : boost::noncopyable {
+class Singleton {
 public:
 	Singleton() { }
+	Singleton(const Singleton&) = delete;
+	Singleton& operator=(const Singleton&) = delete;
 	virtual ~Singleton() { }
 
 	static T* getInstance() {

--- a/airdcpp-core/airdcpp/core/geo/GeoIP.h
+++ b/airdcpp-core/airdcpp/core/geo/GeoIP.h
@@ -29,8 +29,10 @@ namespace dcpp {
 using std::string;
 using std::vector;
 
-class GeoIP : public boost::noncopyable {
+class GeoIP {
 public:
+	GeoIP(const GeoIP&) = delete;
+	GeoIP& operator=(const GeoIP&) = delete;
 	explicit GeoIP(string&& path);
 	~GeoIP();
 

--- a/airdcpp-core/airdcpp/core/io/FileReader.cpp
+++ b/airdcpp-core/airdcpp/core/io/FileReader.cpp
@@ -103,7 +103,9 @@ void* FileReader::align(void *buf, size_t alignment) {
 
 #ifdef _WIN32
 
-struct Handle : boost::noncopyable {
+struct Handle {
+	Handle(const Handle&) = delete;
+	Handle& operator=(const Handle&) = delete;
 	Handle(HANDLE h) : h(h) { }
 	~Handle() { ::CloseHandle(h); }
 

--- a/airdcpp-core/airdcpp/core/io/FileReader.h
+++ b/airdcpp-core/airdcpp/core/io/FileReader.h
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/noncopyable.hpp>
+
 
 namespace dcpp {
 
@@ -34,8 +34,10 @@ using std::vector;
 
 /** Helper class for reading an entire file */
 
-class FileReader : boost::noncopyable {
+class FileReader {
 public:
+	FileReader(const FileReader&) = delete;
+	FileReader& operator=(const FileReader&) = delete;
 
 	enum Strategy {
 		ASYNC = 1,

--- a/airdcpp-core/airdcpp/core/io/compress/ZipFile.h
+++ b/airdcpp-core/airdcpp/core/io/compress/ZipFile.h
@@ -37,7 +37,7 @@
 #include <memory>
 #include <utility>
 
-#include <boost/noncopyable.hpp>
+
 #ifdef STD_MAP_STD_UNIQUE_PTR_BUG
 #include <boost/shared_array.hpp>
 #endif
@@ -70,9 +70,11 @@ private:
 	static string TranslateError(int e);
 };
 
-class ZipFile : private boost::noncopyable 
+class ZipFile 
 {
 public:
+	ZipFile(const ZipFile&) = delete;
+	ZipFile& operator=(const ZipFile&) = delete;
 	struct FileInfo {
 		FileInfo() : name(Util::emptyString), time((time_t)-1), size(-1) { }
 		FileInfo(string zfn, time_t zft, int64_t zfs) : name(zfn), time(zft), size(zfs) { }

--- a/airdcpp-core/airdcpp/core/io/db/DbHandler.h
+++ b/airdcpp-core/airdcpp/core/io/db/DbHandler.h
@@ -35,8 +35,10 @@ class DbSnapshot {
 };
 
 // Most methods throw DbException in case of errors
-class DbHandler : boost::noncopyable {
+class DbHandler {
 public:
+	DbHandler(const DbHandler&) = delete;
+	DbHandler& operator=(const DbHandler&) = delete;
 	virtual DbSnapshot* getSnapshot() { return nullptr; }
 
 	virtual void repair(StepFunction stepF, MessageFunction messageF) = 0;

--- a/airdcpp-core/airdcpp/core/io/stream/StreamBase.h
+++ b/airdcpp-core/airdcpp/core/io/stream/StreamBase.h
@@ -20,7 +20,7 @@
 #ifndef DCPLUSPLUS_DCPP_STREAMBASE_H
 #define DCPLUSPLUS_DCPP_STREAMBASE_H
 
-#include <boost/noncopyable.hpp>
+
 
 #include <airdcpp/core/header/typedefs.h>
 
@@ -29,9 +29,11 @@ namespace dcpp {
 /**
 	* A simple output stream. Intended to be used for nesting streams one inside the other.
 	*/
-class OutputStream : public boost::noncopyable {
+class OutputStream {
 public:
 	OutputStream() = default;
+	OutputStream(const OutputStream&) = delete;
+	OutputStream& operator=(const OutputStream&) = delete;
 	virtual ~OutputStream() = default;
 
 	/**
@@ -64,9 +66,11 @@ public:
 	virtual OutputStream* releaseRootStream() { return this; }
 };
 
-class InputStream : public boost::noncopyable {
+class InputStream {
 public:
 	InputStream() = default;
+	InputStream(const InputStream&) = delete;
+	InputStream& operator=(const InputStream&) = delete;
 	virtual ~InputStream() = default;
 	/**
 		* Call this function until it returns 0 to get all bytes.

--- a/airdcpp-core/airdcpp/core/io/xml/SimpleXML.h
+++ b/airdcpp-core/airdcpp/core/io/xml/SimpleXML.h
@@ -24,7 +24,7 @@
 
 #include <airdcpp/core/io/xml/SimpleXMLReader.h>
 
-#include <boost/noncopyable.hpp>
+
 
 namespace dcpp {
 
@@ -32,9 +32,11 @@ namespace dcpp {
  * A simple XML class that loads an XML-ish structure into an internal tree
  * and allows easy access to each element through a "current location".
  */
-class SimpleXML : private boost::noncopyable
+class SimpleXML
 {
 public:
+	SimpleXML(const SimpleXML&) = delete;
+	SimpleXML& operator=(const SimpleXML&) = delete;
 	SimpleXML();
 	~SimpleXML() = default;
 	
@@ -136,8 +138,10 @@ public:
 	}
 	static const string utf8Header;
 private:
-	class Tag : public boost::noncopyable {
+	class Tag {
 	public:
+		Tag(const Tag&) = delete;
+		Tag& operator=(const Tag&) = delete;
 		using Ptr = Tag *;
 		using List = vector<Ptr>;
 		using Iter = List::iterator;

--- a/airdcpp-core/airdcpp/core/io/xml/SimpleXMLReader.h
+++ b/airdcpp-core/airdcpp/core/io/xml/SimpleXMLReader.h
@@ -22,13 +22,16 @@
 #include <airdcpp/core/header/typedefs.h>
 #include <airdcpp/core/io/File.h>
 
-#include <boost/noncopyable.hpp>
+
 
 namespace dcpp {
 
 class SimpleXMLReader {
 public:
-	struct CallBack : private boost::noncopyable {
+	struct CallBack {
+		CallBack() = default;
+		CallBack(const CallBack&) = delete;
+		CallBack& operator=(const CallBack&) = delete;
 		virtual ~CallBack() = default;
 
 		/** A new XML tag has been encountered.

--- a/airdcpp-core/airdcpp/filelist/DirectoryListingDirectory.h
+++ b/airdcpp-core/airdcpp/filelist/DirectoryListingDirectory.h
@@ -33,9 +33,11 @@ namespace dcpp {
 
 class SearchQuery;
 
-class DirectoryListing::File: public boost::noncopyable {
+class DirectoryListing::File {
 
 public:
+	File(const File&) = delete;
+	File& operator=(const File&) = delete;
 	using Owner = const void*;
 	using Ptr = std::shared_ptr<File>;
 
@@ -79,8 +81,10 @@ enum class DirectoryListing::DirectoryLoadType {
 	NONE,
 };
 
-class DirectoryListing::Directory : public boost::noncopyable {
+class DirectoryListing::Directory {
 public:
+	Directory(const Directory&) = delete;
+	Directory& operator=(const Directory&) = delete;
 	enum DirType {
 		TYPE_NORMAL,
 		TYPE_INCOMPLETE_CHILD,

--- a/airdcpp-core/airdcpp/hub/Client.h
+++ b/airdcpp-core/airdcpp/hub/Client.h
@@ -35,7 +35,7 @@
 #include <airdcpp/search/SearchQueue.h>
 #include <airdcpp/core/Speaker.h>
 
-#include <boost/noncopyable.hpp>
+
 
 namespace dcpp {
 
@@ -59,8 +59,10 @@ public:
 /** Yes, this should probably be called a Hub */
 class Client : 
 	public ClientBase, public ChatHandlerBase, public Speaker<ClientListener>, public BufferedSocketListener, protected TimerManagerListener, 
-	private ShareProfileManagerListener, public HubSettings, private boost::noncopyable {
+	private ShareProfileManagerListener, public HubSettings {
 public:
+	Client(const Client&) = delete;
+	Client& operator=(const Client&) = delete;
 	using UrlMap = unordered_map<string *, ClientPtr, noCaseStringHash, noCaseStringEq>;
 	using IdMap = unordered_map<ClientToken, ClientPtr>;
 

--- a/airdcpp-core/airdcpp/modules/RSSManager.h
+++ b/airdcpp-core/airdcpp/modules/RSSManager.h
@@ -77,8 +77,10 @@ public:
 
 };
 
-class RSS : private boost::noncopyable {
+class RSS {
 public:
+	RSS(const RSS&) = delete;
+	RSS& operator=(const RSS&) = delete;
 
 	RSS(const string& aUrl, const string& aName, bool aEnable, time_t aLastUpdate, int aUpdateInterval = 60, int aToken = 0) noexcept :
 		url(aUrl), feedName(aName), lastUpdate(aLastUpdate), updateInterval(aUpdateInterval), token(aToken), enable(aEnable)
@@ -130,8 +132,10 @@ private:
 
 };
 
-class RSSData: private boost::noncopyable {
+class RSSData {
 public:
+	RSSData(const RSSData&) = delete;
+	RSSData& operator=(const RSSData&) = delete;
 	RSSData(const string& aTitle, const string& aLink, const string& aPubDate, const RSSPtr& aFeed, time_t aDateAdded = GET_TIME()) noexcept :
 		title(aTitle), link(aLink), pubDate(aPubDate), feed(aFeed), dateAdded(aDateAdded)  {
 	}

--- a/airdcpp-core/airdcpp/private_chat/PrivateChat.h
+++ b/airdcpp-core/airdcpp/private_chat/PrivateChat.h
@@ -29,8 +29,10 @@
 
 namespace dcpp {
 	class PrivateChat: public ChatHandlerBase, public Speaker<PrivateChatListener>, public UserConnectionListener,
-		private ClientManagerListener, private boost::noncopyable {
+		private ClientManagerListener {
 	public:
+		PrivateChat(const PrivateChat&) = delete;
+		PrivateChat& operator=(const PrivateChat&) = delete;
 		
 		enum PMInfo: uint8_t {
 			//CPMI types

--- a/airdcpp-core/airdcpp/stdinc.h
+++ b/airdcpp-core/airdcpp/stdinc.h
@@ -81,7 +81,6 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/scoped_array.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/regex.hpp>
 
 namespace dcpp {

--- a/airdcpp-core/airdcpp/transfer/Transfer.h
+++ b/airdcpp-core/airdcpp/transfer/Transfer.h
@@ -29,8 +29,10 @@
 
 namespace dcpp {
 
-class Transfer : private boost::noncopyable {
+class Transfer {
 public:
+	Transfer(const Transfer&) = delete;
+	Transfer& operator=(const Transfer&) = delete;
 	enum Type {
 		TYPE_FILE,
 		TYPE_FULL_LIST,

--- a/airdcpp-core/airdcpp/user/OnlineUser.h
+++ b/airdcpp-core/airdcpp/user/OnlineUser.h
@@ -21,7 +21,7 @@
 
 #include <map>
 
-#include <boost/noncopyable.hpp>
+
 
 #include <airdcpp/forward.h>
 
@@ -195,8 +195,10 @@ private:
 	SupportList supports;
 };
 
-class OnlineUser final :  public FastAlloc<OnlineUser>, private boost::noncopyable {
+class OnlineUser final :  public FastAlloc<OnlineUser> {
 public:
+	OnlineUser(const OnlineUser&) = delete;
+	OnlineUser& operator=(const OnlineUser&) = delete;
 	static const string CLIENT_PROTOCOL;
 	static const string SECURE_CLIENT_PROTOCOL_TEST;
 	static const string ADCS_FEATURE;

--- a/airdcpp-webapi/api/common/PropertyFilter.h
+++ b/airdcpp-webapi/api/common/PropertyFilter.h
@@ -28,8 +28,10 @@ namespace webserver {
 	using FilterToken = uint32_t;
 
 
-	class PropertyFilter : public boost::noncopyable {
+	class PropertyFilter {
 	public:
+		PropertyFilter(const PropertyFilter&) = delete;
+		PropertyFilter& operator=(const PropertyFilter&) = delete;
 		using InfoFunction = std::function<std::string (int)>;
 		using NumericFunction = std::function<double (int)>;
 		using CustomFilterFunction = std::function<bool (int, const StringMatch &, double)>;

--- a/airdcpp-webapi/web-server/Timer.h
+++ b/airdcpp-webapi/web-server/Timer.h
@@ -26,8 +26,10 @@
 #include <chrono>
 
 namespace webserver {
-	class Timer : public boost::noncopyable {
+	class Timer {
 	public:
+		Timer(const Timer&) = delete;
+		Timer& operator=(const Timer&) = delete;
 		using CallbackWrapper = std::function<void (const Callback &)>;
 
 		// CallbackWrapper is meant to ensure the lifetime of the timer


### PR DESCRIPTION
## Summary

Replace all usages of `boost::noncopyable` with C++11 deleted copy constructor and copy assignment operator.

## Motivation

`boost::noncopyable` is a legacy pattern from pre-C++11. Since the project targets C++20, the standard `= delete` syntax is preferred:

- Removes a Boost dependency from 24 header files and 1 cpp file
- Uses idiomatic modern C++ (Core Guideline C.67)
- Zero runtime impact — purely a compile-time enforcement