### PR TITLE
Replace boost::format with std::format

### DIFF
--- a/airdcpp-core/airdcpp/DCPlusPlus.cpp
+++ b/airdcpp-core/airdcpp/DCPlusPlus.cpp
@@ -19,7 +19,6 @@
 #include "stdinc.h"
 #include <airdcpp/DCPlusPlus.h>
 
-#include <airdcpp/core/header/format.h>
 #include <airdcpp/util/AppUtil.h>
 #include <airdcpp/core/io/File.h>
 #include <airdcpp/util/PathUtil.h>

--- a/airdcpp-core/airdcpp/connection/ConnectionManager.cpp
+++ b/airdcpp-core/airdcpp/connection/ConnectionManager.cpp
@@ -30,6 +30,7 @@
 #include <airdcpp/transfer/upload/UploadManager.h>
 #include <airdcpp/connection/UserConnection.h>
 #include <airdcpp/util/ValueGenerator.h>
+#include <format>
 
 namespace dcpp {
 FastCriticalSection TokenManager::cs;
@@ -587,7 +588,7 @@ int ConnectionManager::Server::run() noexcept {
 				dcdebug("ConnectionManager::Server::run Stopped listening: %s\n", e.getError().c_str());
 
 				if(!failed) {
-					LogManager::getInstance()->message(str(boost::format("Connectivity error: %1%") % e.getError()), LogMessage::SEV_ERROR, STRING(CONNECTIVITY));
+					LogManager::getInstance()->message(std::format("Connectivity error: {}", e.getError()), LogMessage::SEV_ERROR, STRING(CONNECTIVITY));
 					failed = true;
 				}
 

--- a/airdcpp-core/airdcpp/connection/http/HttpConnection.cpp
+++ b/airdcpp-core/airdcpp/connection/http/HttpConnection.cpp
@@ -21,13 +21,12 @@
 
 #include <airdcpp/connection/socket/BufferedSocket.h>
 #include <airdcpp/util/LinkUtil.h>
-#include <airdcpp/core/header/format.h>
+#include <format>
 #include <airdcpp/settings/SettingsManager.h>
 #include <airdcpp/util/SystemUtil.h>
 #include <airdcpp/core/version.h>
 
 #include <airdcpp/core/localization/ResourceManager.h>
-#include <airdcpp/core/header/format.h>
 
 #include <boost/algorithm/string/trim.hpp>
 
@@ -205,7 +204,7 @@ void HttpConnection::on(BufferedSocketListener::Line, const string& aLine) noexc
 				error.pop_back(); // These would cause issues in HTTP messages
 			}
 
-			fire(HttpConnectionListener::Failed(), this, str(boost::format("%1% (%2%)") % error % currentUrl));
+			fire(HttpConnectionListener::Failed(), this, std::format("{} ({})", error, currentUrl));
 			if (isUnique) { delete this; return; }
 			connState = CONN_FAILED;
 		}
@@ -277,7 +276,7 @@ void HttpConnection::on(BufferedSocketListener::Failed, const string& aLine) noe
 	abortRequest(false);
 
 	connState = CONN_FAILED;
-	fire(HttpConnectionListener::Failed(), this, str(boost::format("%1% (%2%)") % aLine % currentUrl));
+	fire(HttpConnectionListener::Failed(), this, std::format("{} ({})", aLine, currentUrl));
 	if (isUnique) delete this;
 }
 

--- a/airdcpp-core/airdcpp/connection/socket/SSLSocket.cpp
+++ b/airdcpp-core/airdcpp/connection/socket/SSLSocket.cpp
@@ -22,7 +22,7 @@
 #include <airdcpp/events/LogManager.h>
 #include <airdcpp/settings/SettingsManager.h>
 #include <airdcpp/core/localization/ResourceManager.h>
-#include <airdcpp/core/header/format.h>
+#include <format>
 #include <airdcpp/util/text/StringTokenizer.h>
 
 #include <openssl/err.h>

--- a/airdcpp-core/airdcpp/connection/socket/Socket.cpp
+++ b/airdcpp-core/airdcpp/connection/socket/Socket.cpp
@@ -20,7 +20,7 @@
 #include <airdcpp/connection/socket/Socket.h>
 
 #include <airdcpp/connectivity/ConnectivityManager.h>
-#include <airdcpp/core/header/format.h>
+#include <format>
 #include <airdcpp/settings/SettingsManager.h>
 #include <airdcpp/core/timer/TimerManager.h>
 #include <airdcpp/core/localization/ResourceManager.h>
@@ -206,7 +206,7 @@ static const uint32_t SOCKS_TIMEOUT = 30000;
 string SocketException::errorToString(int aError) noexcept {
 	string msg = SystemUtil::translateError(aError);
 	if(msg.empty()) {
-		msg = str(boost::format("Unknown error: 0x%1$x") % aError);
+		msg = std::format("Unknown error: 0x{:x}", aError);
 	}
 
 	return msg;
@@ -229,7 +229,7 @@ socket_t Socket::setSock(socket_t s, int af) {
 		setSocketOpt2(s, IPPROTO_IPV6, IPV6_V6ONLY, 1);
 		sock6 = s;
 	} else {
-		throw SocketException(str(boost::format("Unknown protocol %d") % af));
+		throw SocketException(std::format("Unknown protocol {}", af));
 	}
 
 	return s;

--- a/airdcpp-core/airdcpp/connectivity/ConnectivityManager.cpp
+++ b/airdcpp-core/airdcpp/connectivity/ConnectivityManager.cpp
@@ -23,7 +23,7 @@
 #include <airdcpp/connection/ConnectionManager.h>
 #include <airdcpp/DCPlusPlus.h>
 #include <airdcpp/favorites/FavoriteManager.h>
-#include <airdcpp/core/header/format.h>
+#include <format>
 #include <airdcpp/events/LogManager.h>
 #include <airdcpp/connectivity/MappingManager.h>
 #include <airdcpp/util/NetworkUtil.h>
@@ -385,8 +385,8 @@ string ConnectivityManager::getInformation() const {
 		return "Connectivity settings are being configured; try again later";
 	}
 
-	string autoStatusV4 = ok(false) ? str(boost::format("enabled - %1%") % getStatus(false)) : "disabled";
-	string autoStatusV6 = ok(true) ? str(boost::format("enabled - %1%") % getStatus(true)) : "disabled";
+	string autoStatusV4 = ok(false) ? std::format("enabled - {}", getStatus(false)) : "disabled";
+	string autoStatusV6 = ok(true) ? std::format("enabled - {}", getStatus(true)) : "disabled";
 
 	auto getMode = [&](bool v6) -> string { 
 		switch(v6 ? CONNSETTING(INCOMING_CONNECTIONS6) : CONNSETTING(INCOMING_CONNECTIONS)) {
@@ -397,7 +397,7 @@ string ConnectivityManager::getInformation() const {
 			}
 		case SettingsManager::INCOMING_ACTIVE_UPNP:
 			{
-				return str(boost::format("Active mode behind a router that %1% can configure; port mapping status: %2%") % APPNAME % (v6 ? mapperV6.getStatus() : mapperV4.getStatus()));
+				return std::format("Active mode behind a router that {} can configure; port mapping status: {}", APPNAME, (v6 ? mapperV6.getStatus() : mapperV4.getStatus()));
 				break;
 			}
 		case SettingsManager::INCOMING_PASSIVE:
@@ -412,23 +412,24 @@ string ConnectivityManager::getInformation() const {
 
 	auto field = [](const string& s) { return s.empty() ? "undefined" : s; };
 
-	return str(boost::format(
+	return std::format(
 		"Connectivity information:\n\n"
-		"Automatic connectivity setup (v4) is: %1%\n\n"
-		"Automatic connectivity setup (v6) is: %2%\n\n"
-		"\tMode (v4): %3%\n"
-		"\tMode (v6): %4%\n"
-		"\tExternal IP (v4): %5%\n"
-		"\tExternal IP (v6): %6%\n"
-		"\tBound interface (v4): %7%\n"
-		"\tBound interface (v6): %8%\n"
-		"\tTransfer port: %9%\n"
-		"\tSearch port: %11%\n"
-		"\tEncrypted transfer port: %10%") % autoStatusV4 % autoStatusV6 % getMode(false) % getMode(true) %
-		field(CONNSETTING(EXTERNAL_IP)) % field(CONNSETTING(EXTERNAL_IP6)) %
-		field(CONNSETTING(BIND_ADDRESS)) % field(CONNSETTING(BIND_ADDRESS6)) %
-		field(ConnectionManager::getInstance()->getPort()) % field(ConnectionManager::getInstance()->getSecurePort()) %
-		field(SearchManager::getInstance()->getPort()));
+		"Automatic connectivity setup (v4) is: {}\n\n"
+		"Automatic connectivity setup (v6) is: {}\n\n"
+		"\tMode (v4): {}\n"
+		"\tMode (v6): {}\n"
+		"\tExternal IP (v4): {}\n"
+		"\tExternal IP (v6): {}\n"
+		"\tBound interface (v4): {}\n"
+		"\tBound interface (v6): {}\n"
+		"\tTransfer port: {}\n"
+		"\tSearch port: {}\n"
+		"\tEncrypted transfer port: {}",
+		autoStatusV4, autoStatusV6, getMode(false), getMode(true),
+		field(CONNSETTING(EXTERNAL_IP)), field(CONNSETTING(EXTERNAL_IP6)),
+		field(CONNSETTING(BIND_ADDRESS)), field(CONNSETTING(BIND_ADDRESS6)),
+		field(ConnectionManager::getInstance()->getPort()), field(SearchManager::getInstance()->getPort()),
+		field(ConnectionManager::getInstance()->getSecurePort()));
 }
 
 void ConnectivityManager::startMapping(bool v6) {

--- a/airdcpp-core/airdcpp/connectivity/MappingManager.cpp
+++ b/airdcpp-core/airdcpp/connectivity/MappingManager.cpp
@@ -21,7 +21,7 @@
 
 #include <airdcpp/connection/ConnectionManager.h>
 #include <airdcpp/connectivity/ConnectivityManager.h>
-#include <airdcpp/core/header/format.h>
+#include <format>
 #include <airdcpp/events/LogManager.h>
 
 #include <airdcpp/connectivity/mappers/Mapper_MiniUPnPc.h>

--- a/airdcpp-core/airdcpp/core/geo/GeoIP.cpp
+++ b/airdcpp-core/airdcpp/core/geo/GeoIP.cpp
@@ -22,7 +22,7 @@
 #include <airdcpp/core/classes/Exception.h>
 #include <airdcpp/core/io/File.h>
 #include <airdcpp/core/localization/Localization.h>
-#include <airdcpp/core/header/format.h>
+#include <format>
 #include <airdcpp/settings/SettingsManager.h>
 #include <airdcpp/util/Util.h>
 #include <airdcpp/core/io/compress/ZUtils.h>

--- a/airdcpp-core/airdcpp/core/io/compress/ZUtils.cpp
+++ b/airdcpp-core/airdcpp/core/io/compress/ZUtils.cpp
@@ -21,7 +21,7 @@
 
 #include <airdcpp/core/classes/Exception.h>
 #include <airdcpp/core/io/File.h>
-#include <airdcpp/core/header/format.h>
+#include <format>
 #include <airdcpp/core/classes/ScopedFunctor.h>
 #include <airdcpp/settings/SettingsManager.h>
 

--- a/airdcpp-core/airdcpp/core/update/updater/UpdaterCreator.cpp
+++ b/airdcpp-core/airdcpp/core/update/updater/UpdaterCreator.cpp
@@ -22,7 +22,7 @@
 
 #include <airdcpp/core/update/UpdateConstants.h>
 
-#include <airdcpp/core/header/format.h>
+#include <format>
 
 #include <airdcpp/util/AppUtil.h>
 #include <airdcpp/util/CryptoUtil.h>
@@ -173,7 +173,7 @@ bool UpdaterCreator::writePublicKey(const string& aOutputPath, const ByteVector&
 
 	c_key += "uint8_t dcpp::UpdateManager::publicKey[] = { " NATIVE_NL "\t";
 	for (int i = 0; i < aPubKey.size(); ++i) {
-		c_key += (dcpp_fmt("0x%02X") % (unsigned int)aPubKey[i]).str();
+		c_key += std::format("0x{:02X}", static_cast<unsigned int>(aPubKey[i]));
 		if (i < aPubKey.size() - 1) {
 			c_key += ", ";
 			if ((i + 1) % 15 == 0) c_key += NATIVE_NL "\t";

--- a/airdcpp-core/airdcpp/private_chat/PrivateChat.cpp
+++ b/airdcpp-core/airdcpp/private_chat/PrivateChat.cpp
@@ -24,6 +24,7 @@
 #include <airdcpp/core/crypto/CryptoManager.h>
 #include <airdcpp/events/LogManager.h>
 #include <airdcpp/message/Message.h>
+#include <format>
 
 
 namespace dcpp {
@@ -117,13 +118,11 @@ void PrivateChat::checkCCPMHubBlocked() noexcept {
 		return;
 	}
 
-	auto msg = boost::str(boost::format(
-"%s\r\n\r\n\
-%s")
-
-% STRING_F(CCPM_BLOCKED_WARNING, hubName)
-% (getUser()->isSet(User::CCPM) ? STRING(OTHER_CCPM_SUPPORTED) : STRING(OTHER_MEANS_COMMUNICATION))
-);
+	auto msg = std::format(
+		"{}\r\n\r\n{}",
+		STRING_F(CCPM_BLOCKED_WARNING, hubName),
+		(getUser()->isSet(User::CCPM) ? STRING(OTHER_CCPM_SUPPORTED) : STRING(OTHER_MEANS_COMMUNICATION))
+	);
 
 	statusMessage(msg, LogMessage::SEV_WARNING, LogMessage::Type::SYSTEM);
 }


### PR DESCRIPTION
## Summary

Replace all usages of `boost::format` with C++20 `std::format`.

## Motivation

`std::format` is significantly faster and produces smaller binaries than `boost::format`:

| Metric | std::format | boost::format | Improvement |
|--------|-------------|---------------|-------------|
| Runtime | 0.44s | 3.89s | **~9x faster** |
| Compile time | 5.0s | 55.0s | **~11x faster** |
| Binary size | 54 KiB | 530 KiB | **~10x smaller** |

*Benchmarks from [fmtlib/fmt](https://github.com/fmtlib/fmt).*

Additionally:
- ~Removes the `airdcpp/core/header/format.h` wrapper file~
- Removes the Boost.Format dependency from 11 source files
- Uses compile-time format string validation (catches errors at compile time)