### PR TITLE
refactor: replace boost::variant with std::variant

### DIFF
--- a/airdcpp-core/airdcpp/connectivity/ConnectivityManager.cpp
+++ b/airdcpp-core/airdcpp/connectivity/ConnectivityManager.cpp
@@ -101,7 +101,7 @@ bool ConnectivityManager::get(SettingsManager::BoolSetting setting) const {
 		RLock l(cs);
 		auto i = autoSettings.find(setting);
 		if(i != autoSettings.end()) {
-			return boost::get<bool>(i->second);
+			return std::get<bool>(i->second);
 		}
 	}
 	return SettingsManager::getInstance()->get(setting);
@@ -112,7 +112,7 @@ int ConnectivityManager::get(SettingsManager::IntSetting setting) const {
 		RLock l(cs);
 		auto i = autoSettings.find(setting);
 		if(i != autoSettings.end()) {
-			return boost::get<int>(i->second);
+			return std::get<int>(i->second);
 		}
 	}
 	return SettingsManager::getInstance()->get(setting);
@@ -123,7 +123,7 @@ const string& ConnectivityManager::get(SettingsManager::StrSetting setting) cons
 		RLock l(cs);
 		auto i = autoSettings.find(setting);
 		if(i != autoSettings.end()) {
-			return boost::get<string>(i->second);
+			return std::get<string>(i->second);
 		}
 	}
 	return SettingsManager::getInstance()->get(setting);
@@ -370,9 +370,9 @@ void ConnectivityManager::editAutoSettings() {
 	auto sm = SettingsManager::getInstance();
 	for(auto i = autoSettings.cbegin(), iend = autoSettings.cend(); i != iend; ++i) {
 		if(i->first >= SettingsManager::STR_FIRST && i->first < SettingsManager::STR_LAST) {
-			sm->set(static_cast<SettingsManager::StrSetting>(i->first), boost::get<string>(i->second));
+			sm->set(static_cast<SettingsManager::StrSetting>(i->first), std::get<string>(i->second));
 		} else if(i->first >= SettingsManager::INT_FIRST && i->first < SettingsManager::INT_LAST) {
-			sm->set(static_cast<SettingsManager::IntSetting>(i->first), boost::get<int>(i->second));
+			sm->set(static_cast<SettingsManager::IntSetting>(i->first), std::get<int>(i->second));
 		}
 	}
 	autoSettings.clear();

--- a/airdcpp-core/airdcpp/connectivity/ConnectivityManager.h
+++ b/airdcpp-core/airdcpp/connectivity/ConnectivityManager.h
@@ -30,7 +30,7 @@
 
 #include <string>
 #include <unordered_map>
-#include <boost/variant.hpp>
+#include <variant>
 
 namespace dcpp {
 
@@ -103,7 +103,7 @@ private:
 	/* contains auto-detected settings. they are stored separately from manual connectivity
 	settings (stored in SettingsManager) in case the user wants to keep the manually set ones for
 	future use. */
-	unordered_map<int, boost::variant<bool, int, string>> autoSettings;
+	unordered_map<int, std::variant<bool, int, string>> autoSettings;
 
 	MappingManager mapperV4;
 	MappingManager mapperV6;

--- a/airdcpp-core/airdcpp/core/header/typedefs.h
+++ b/airdcpp-core/airdcpp/core/header/typedefs.h
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <airdcpp/forward.h>
 
-#include <boost/variant.hpp>
+#include <variant>
 
 namespace dcpp {
 
@@ -82,7 +82,7 @@ typedef StringMap TStringMap;
 
 #endif
 
-using ParamMap = unordered_map<string, boost::variant<string, std::function<string ()>>>;
+using ParamMap = unordered_map<string, std::variant<string, std::function<string ()>>>;
 
 }
 

--- a/airdcpp-core/airdcpp/settings/SettingItem.cpp
+++ b/airdcpp-core/airdcpp/settings/SettingItem.cpp
@@ -68,7 +68,7 @@ const string& SettingItem::getDescription() const noexcept {
 
 string SettingItem::currentToString() const noexcept {
 	auto cur = getCurValue(true);
-	return boost::apply_visitor(ToString(key), cur);
+	return std::visit(ToString(key), cur);
 }
 
 string SettingItem::ToString::operator()(const string& s) const noexcept {
@@ -82,10 +82,6 @@ string SettingItem::ToString::operator()(int val) const noexcept {
 	}
 
 	return Util::toString(val);
-}
-
-string SettingItem::ToString::operator()(double d) const noexcept {
-	return Util::toString(d);
 }
 
 string SettingItem::ToString::operator()(bool b) const noexcept {
@@ -103,7 +99,7 @@ bool ProfileSettingItem::isProfileCurrent() const noexcept {
 }
 
 string ProfileSettingItem::profileToString() const noexcept {
-	return boost::apply_visitor(ToString(key), profileValue);
+	return std::visit(ToString(key), profileValue);
 }
 
 void ProfileSettingItem::setProfileToDefault(bool aReset) const noexcept {
@@ -111,11 +107,11 @@ void ProfileSettingItem::setProfileToDefault(bool aReset) const noexcept {
 		SettingsManager::getInstance()->unsetKey(key);
 
 	if (key >= SettingsManager::STR_FIRST && key < SettingsManager::STR_LAST) {
-		SettingsManager::getInstance()->setDefault(static_cast<SettingsManager::StrSetting>(key), boost::get<string>(profileValue));
+		SettingsManager::getInstance()->setDefault(static_cast<SettingsManager::StrSetting>(key), std::get<string>(profileValue));
 	} else if (key >= SettingsManager::INT_FIRST && key < SettingsManager::INT_LAST) {
-		SettingsManager::getInstance()->setDefault(static_cast<SettingsManager::IntSetting>(key), boost::get<int>(profileValue));
+		SettingsManager::getInstance()->setDefault(static_cast<SettingsManager::IntSetting>(key), std::get<int>(profileValue));
 	} else if (key >= SettingsManager::BOOL_FIRST && key < SettingsManager::BOOL_LAST) {
-		SettingsManager::getInstance()->setDefault(static_cast<SettingsManager::BoolSetting>(key), boost::get<bool>(profileValue));
+		SettingsManager::getInstance()->setDefault(static_cast<SettingsManager::BoolSetting>(key), std::get<bool>(profileValue));
 	} else {
 		dcassert(0);
 	}

--- a/airdcpp-core/airdcpp/settings/SettingItem.h
+++ b/airdcpp-core/airdcpp/settings/SettingItem.h
@@ -23,13 +23,13 @@
 
 #include <airdcpp/core/localization/ResourceManager.h>
 
-#include <boost/variant.hpp>
+#include <variant>
 
 namespace dcpp {
 
 
 struct SettingItem {
-	using SettingValue = boost::variant<string, bool, int, double>;
+	using SettingValue = std::variant<bool, int, string>;
 	using List = vector<SettingItem>;
 
 	const int key;
@@ -45,12 +45,11 @@ struct SettingItem {
 	const string& getDescription() const noexcept;
 	string currentToString() const noexcept;
 
-	struct ToString : boost::static_visitor<string> {
+	struct ToString {
 		explicit ToString(int aKey) : key(aKey) { }
 
 		string operator()(const string& s) const noexcept;
 		string operator()(int s) const noexcept;
-		string operator()(double d) const noexcept;
 		string operator()(bool b) const noexcept;
 	private:
 		const int key;

--- a/airdcpp-core/airdcpp/settings/SettingsManager.h
+++ b/airdcpp-core/airdcpp/settings/SettingsManager.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (C) 20 01-2024 Jacek Sieka, arnetheduck on gmailpoint com
  *
  * This program is free software; you can redistribute it and/or modif
@@ -316,7 +316,7 @@ public:
 	static const ResourceManager::Strings dropStrings[QUEUE_LAST];
 	static const ResourceManager::Strings updateStrings[VERSION_LAST];
 
-	using SettingValue = boost::variant<bool, int, string>;
+	using SettingValue = std::variant<bool, int, string>;
 	using SettingValueList = vector<SettingValue>;
 
 	using SettingKeyList = vector<int>;

--- a/airdcpp-core/airdcpp/util/Util.cpp
+++ b/airdcpp-core/airdcpp/util/Util.cpp
@@ -300,8 +300,8 @@ int Util::strnicmp(const char* a, const char* b, size_t n) noexcept {
 	return (a >= end) ? 0 : ((int)Text::toLower(ca) - (int)Text::toLower(cb));
 }
 
-// used to parse the boost::variant params of the formatParams function.
-struct GetString : boost::static_visitor<string> {
+// used to parse the std::variant params of the formatParams function.
+struct GetString {
 	string operator()(const string& s) const noexcept { return s; }
 	string operator()(const std::function<string ()>& f) const noexcept { return f(); }
 };
@@ -332,7 +332,7 @@ string Util::formatParams(const string& aMsg, const ParamMap& aParams, FilterF a
 			i = j;
 
 		} else {
-			auto replacement = boost::apply_visitor(GetString(), param->second);
+			auto replacement = std::visit(GetString(), param->second);
 
 			// replace all % in params with %% for strftime
 			replace("%", "%%", replacement);

--- a/airdcpp-core/airdcpp/util/text/StringMatch.cpp
+++ b/airdcpp-core/airdcpp/util/text/StringMatch.cpp
@@ -36,7 +36,7 @@ StringMatch StringMatch::getSearch(const string& aPattern, Method aMethod) {
 }
 
 StringMatch::Method StringMatch::getMethod() const noexcept {
-	return boost::get<StringSearch>(&search) ? PARTIAL : boost::get<string>(&search) ? EXACT : isWildCard ? WILDCARD : REGEX;
+	return std::get_if<StringSearch>(&search) ? PARTIAL : std::get_if<string>(&search) ? EXACT : isWildCard ? WILDCARD : REGEX;
 }
 
 void StringMatch::setMethod(Method method) {
@@ -57,7 +57,7 @@ bool StringMatch::operator==(const StringMatch& rhs) const noexcept {
 	return pattern == rhs.pattern && getMethod() == rhs.getMethod();
 }
 
-struct Prepare : boost::static_visitor<bool> {
+struct Prepare {
 	Prepare(const string& aPattern, bool aWildCard, bool aVerbosePatternErrors) : pattern(aPattern), wildCard(aWildCard), verbosePatternErrors(aVerbosePatternErrors) {}
 	Prepare& operator=(const Prepare&) = delete;
 
@@ -100,10 +100,10 @@ private:
 };
 
 bool StringMatch::prepare() {
-	return !pattern.empty() && boost::apply_visitor(Prepare(pattern, isWildCard /*m == WILDCARD*/, verbosePatternErrors), search);
+	return !pattern.empty() && std::visit(Prepare(pattern, isWildCard /*m == WILDCARD*/, verbosePatternErrors), search);
 }
 
-struct Match : boost::static_visitor<bool> {
+struct Match {
 	explicit Match(const string& aStr) : str(aStr) { }
 	Match& operator=(const Match&) = delete;
 
@@ -133,7 +133,7 @@ private:
 };
 
 bool StringMatch::match(const string& str) const {
-	return !str.empty() && boost::apply_visitor(Match(str), search);
+	return !str.empty() && std::visit(Match(str), search);
 }
 
 } // namespace dcpp

--- a/airdcpp-core/airdcpp/util/text/StringMatch.h
+++ b/airdcpp-core/airdcpp/util/text/StringMatch.h
@@ -24,7 +24,7 @@
 
 #include <string>
 
-#include <boost/variant.hpp>
+#include <variant>
 
 namespace dcpp {
 
@@ -58,7 +58,7 @@ struct StringMatch {
 
 
 private:
-	boost::variant<StringSearch, string, boost::regex> search;
+	std::variant<StringSearch, string, boost::regex> search;
 	bool isWildCard = false;
 	bool verbosePatternErrors = true;
 };


### PR DESCRIPTION
## Summary

Replace all usages of `boost::variant` with C++17 `std::variant`, and `boost::apply_visitor`/`boost::static_visitor` with `std::visit` and plain structs.

## Motivation

`std::variant` is the standard replacement for `boost::variant` with key improvements:

| Feature | boost::variant | std::variant |
|---------|----------------|--------------|
| Heap allocation on assignment | Possible | **Never** |
| Visitor syntax | `boost::static_visitor<T>` | Plain struct / lambdas |
| Visit call | `boost::apply_visitor(visitor, var)` | `std::visit(visitor, var)` |
| Index access | `which()` | `index()` |
| Type access | `boost::get<T>` | `std::get<T>` / `std::get_if<T>` |

Additionally:
- Unifies `SettingItem::SettingValue` and `SettingsManager::SettingValue` to use the same type (`variant<bool, int, string>`)
- Removes unused `double` type from `SettingValue` (no double settings exist in `SettingsManager`)
- Removes the Boost.Variant dependency from 4 header files