### PR TITLE
Cache regex compilation in LinkUtil::parseLink

### DIFF
--- a/airdcpp-core/airdcpp/util/LinkUtil.cpp
+++ b/airdcpp-core/airdcpp/util/LinkUtil.cpp
@@ -56,12 +56,12 @@ void LinkUtil::sanitizeUrl(string& url) noexcept {
 string LinkUtil::parseLink(const string& aLink) noexcept {
 
 	// hasScheme: ^[A-Za-z][A-Za-z0-9+.-]*:  OR protocol-relative: ^//
-	const boost::regex reHasScheme(R"(^[A-Za-z][A-Za-z0-9+\-.]*:)", boost::regex::perl);
-	const boost::regex reProtoRelative(R"(^//)", boost::regex::perl);
+	static const boost::regex reHasScheme(R"(^[A-Za-z][A-Za-z0-9+\-.]*:)", boost::regex::perl);
+	static const boost::regex reProtoRelative(R"(^//)", boost::regex::perl);
 	// isEmail: very simple and safe variation
-	const boost::regex reEmail(R"(^[^\s@]+@[^\s@]+\.[^\s@]+$)", boost::regex::perl);
+	static const boost::regex reEmail(R"(^[^\s@]+@[^\s@]+\.[^\s@]+$)", boost::regex::perl);
 	// isUnsafeScheme: javascript: | data: | vbscript:
-	const boost::regex reUnsafe(R"(^(?:javascript|data|vbscript):)", boost::regex::perl | boost::regex::icase);
+	static const boost::regex reUnsafe(R"(^(?:javascript|data|vbscript):)", boost::regex::perl | boost::regex::icase);
 
 	if (!aLink.empty()) {
 		const bool hasScheme = boost::regex_search(aLink, reHasScheme) || boost::regex_search(aLink, reProtoRelative);


### PR DESCRIPTION
## Summary

Add `static` to 4 regex objects in `LinkUtil::parseLink()` to compile them once instead of on every call.

## Motivation

`parseLink()` is called for every link clicked in chat messages (hot path). Without `static`, 4 regex objects are recompiled from scratch on each invocation:

```cpp
// BEFORE: recompiled every call
const boost::regex reHasScheme(R"(^[A-Za-z][A-Za-z0-9+\-.]*:)", boost::regex::perl);
const boost::regex reProtoRelative(R"(^//)", boost::regex::perl);
const boost::regex reEmail(R"(^[^\s@]+@[^\s@]+\.[^\s@]+$)", boost::regex::perl);
const boost::regex reUnsafe(R"(^(?:javascript|data|vbscript):)", boost::regex::perl | boost::regex::icase);
```

Regex compilation involves parsing the pattern, building an NFA/DFA, and allocating internal state.

## Fix

```cpp
// AFTER: compiled once, thread-safe (C++11 guarantee)
static const boost::regex reHasScheme(...);
static const boost::regex reProtoRelative(...);
static const boost::regex reEmail(...);
static const boost::regex reUnsafe(...);
```

`static` local variables in C++11+ are initialized in a thread-safe manner (magic statics), so no additional synchronization is needed.